### PR TITLE
add .out files to .htaccess

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GRANCore
 Type: Package
 Title: Classes and Methods for 'GRANBase'
-Version: 0.2.3
+Version: 0.2.4
 Author: Gabriel Becker[aut,cre], Dinakar Kulkarni [aut,ctb]
 Maintainer: Gabriel Becker <gabembecker@gmail.com>
 Copyright: Genentech Inc

--- a/R/prepdirs.R
+++ b/R/prepdirs.R
@@ -61,7 +61,7 @@ prepDirStructure <- function(basedir, repo_name, temp_repo, temp_checkout,
         # If you're running an Apache HTTP server for your repo, this will
         # enable logs to be viewed as HTML
         if (!file.exists(file.path(dir, ".htaccess"))) {
-            cat("AddType text/html .log .md", file = file.path(dir, ".htaccess"))
+            cat("AddType text/html .log .md .out", file = file.path(dir, ".htaccess"))
         }
     }
 }


### PR DESCRIPTION
Add .out extension to .htaccess so files produced by `R CMD INSTALL` can be rendered in a browser.